### PR TITLE
Make PWA functional

### DIFF
--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -15,5 +15,7 @@
     ],
 		"theme_color": "#F2D7B6",
     "background_color": "#40302B",
-    "display": "standalone"
+    "display": "standalone",
+    "start_url": "/",
+    "lang": "en"
 }


### PR DESCRIPTION
From the commit message:

> Add start_url and lang fields to manifest
> 
> The `start_url` field is required for the PWA to function on Chromium. `lang` is an optional field, which I added because it was appropriate. Tested on mobile Firefox as well.